### PR TITLE
add attributes for optional datadog event

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem 'chefspec', '~> 4.0'
 gem 'berkshelf', '4.3.2'
 gem 'foodcritic', '~> 6.2.0'
 gem 'rubocop', '~> 0.40.0'
+gem 'dogstatsd-ruby', '2.0.0'
 
 group :development do
   gem 'test-kitchen'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
     cucumber-core (1.4.0)
       gherkin (~> 3.2.0)
     diff-lcs (1.2.5)
+    dogstatsd-ruby (2.0.0)
     erubis (2.7.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
@@ -261,10 +262,11 @@ PLATFORMS
 DEPENDENCIES
   berkshelf (= 4.3.2)
   chefspec (~> 4.0)
+  dogstatsd-ruby (= 2.0.0)
   foodcritic (~> 6.2.0)
   kitchen-vagrant
   rubocop (~> 0.40.0)
   test-kitchen
 
 BUNDLED WITH
-   1.12.4
+   1.13.1

--- a/dev.yml
+++ b/dev.yml
@@ -1,4 +1,4 @@
-name: shopify_apt_get_on_change
+name: shopify-apt-get-on-change
 
 up:
   - ruby:
@@ -7,4 +7,3 @@ up:
 
 packages:
   - git@github.com:Shopify/dev-shopify.git
-

--- a/libraries/datadog_push.rb
+++ b/libraries/datadog_push.rb
@@ -1,0 +1,6 @@
+require 'datadog/statsd'
+
+def push_to_datadog(event)
+  statsd = Datadog::Statsd.new('localhost', 8125)
+  statsd.event(event[:name], event[:text], aggregation_key: event[:key])
+end

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -13,4 +13,12 @@ action :update do
     content new_resource.version
     notifies :run, 'execute[apt-get-update]', :immediately
   end
+
+  event = new_resource.datadog_event
+  ruby_block 'datadog' do
+    block do
+      push_to_datadog(event)
+    end
+    only_if { event && event[:name] && event[:text] }
+  end
 end

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -4,3 +4,4 @@ default_action :update if defined?(default_action)
 
 attribute :base_name, name_attribute: true, kind_of: String, required: true
 attribute :version, kind_of: String, required: true
+attribute :datadog_event, kind_of: Hash, required: false, default: nil

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -31,4 +31,57 @@ describe 'shopify_apt_get_on_change_test::default' do
     execute = chef_run.execute('apt-get-update')
     expect(execute.command).to eq 'apt-get -q update'
   end
+
+  it 'should not send a nil event to datadog' do
+    expect(chef_run).to_not run_ruby_block('datadog')
+  end
+end
+
+describe 'shopify_apt_get_on_change_test::datadog' do
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new(step_into: ['shopify_apt_get_on_change'])
+                        .converge(described_recipe)
+  end
+
+  it 'should run the ruby block to send a datadog event' do
+    expect(chef_run).to run_ruby_block('datadog')
+  end
+end
+
+describe 'shopify_apt_get_on_change_test::datadog_noname' do
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new(step_into: ['shopify_apt_get_on_change'])
+                        .converge(described_recipe)
+  end
+
+  it 'should not send an event without an event name to datadog' do
+    expect(chef_run).to_not run_ruby_block('datadog')
+  end
+end
+
+describe 'shopify_apt_get_on_change_test::datadog_notext' do
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new(step_into: ['shopify_apt_get_on_change'])
+                        .converge(described_recipe)
+  end
+
+  it 'should not send an event without event text to datadog' do
+    expect(chef_run).to_not run_ruby_block('datadog')
+  end
+end
+
+describe 'push_to_datadog' do
+  # mock out the datadog statsd
+  let(:statsd) { double('statsd') }
+  before do
+    allow(statsd).to receive(:event)
+    allow(Datadog::Statsd).to receive(:new).and_return(statsd)
+  end
+
+  it 'should send the event to datadog' do
+    expect(statsd).to\
+      receive(:event).with('name', 'text', aggregation_key: 'key')
+
+    push_to_datadog(name: 'name', text: 'text', key: 'key')
+  end
 end

--- a/test/fixtures/cookbooks/shopify_apt_get_on_change_test/recipes/datadog.rb
+++ b/test/fixtures/cookbooks/shopify_apt_get_on_change_test/recipes/datadog.rb
@@ -1,0 +1,10 @@
+shopify_apt_get_on_change '/etc/example.app/version' do
+  event = {
+    name: 'name',
+    text: 'text',
+    key:  'key'
+  }
+
+  version '1.2'
+  datadog_event event
+end

--- a/test/fixtures/cookbooks/shopify_apt_get_on_change_test/recipes/datadog_noname.rb
+++ b/test/fixtures/cookbooks/shopify_apt_get_on_change_test/recipes/datadog_noname.rb
@@ -1,0 +1,9 @@
+shopify_apt_get_on_change '/etc/example.app/version' do
+  event = {
+    text: 'text',
+    key:  'key'
+  }
+
+  version '1.2'
+  datadog_event event
+end

--- a/test/fixtures/cookbooks/shopify_apt_get_on_change_test/recipes/datadog_notext.rb
+++ b/test/fixtures/cookbooks/shopify_apt_get_on_change_test/recipes/datadog_notext.rb
@@ -1,0 +1,9 @@
+shopify_apt_get_on_change '/etc/example.app/version' do
+  event = {
+    name: 'name',
+    key:  'key'
+  }
+
+  version '1.2'
+  datadog_event event
+end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Add a way to optionally send an event to Datadog via statsd on update. This will open up the doors to sending an event for nginx binary deploy as per Shopify/traffic#962 in the `nginx` cookbook.

**What could go wrong? (if anything)**
Event could not get sent

**Rollback steps**
- [x] It is safe to simply rollback this change.
- [x] Users will not be locked out of the nodes (please indicate if users will be locked out)

**Checklist**
- [ ] I have tested my changes locally in test kitchen
- [x] I will make sure my changes pass CI before merging
- [ ] I have :tophat:'d these changes

Reviewers @Shopify/traffic @marc-barry @klautcomputing 
Issue Shopify/traffic#962