### PR TITLE
Trigger datadog event on file update

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -6,19 +6,19 @@ action :update do
     action :nothing
   end
 
+  event = new_resource.datadog_event
+  ruby_block 'datadog' do
+    block   { push_to_datadog(event) }
+    only_if { event && event[:name] && event[:text] }
+    action :nothing
+  end
+
   dir = new_resource.base_name.split('/')[0..-2].join('/')
   directory dir
 
   file new_resource.base_name do
     content new_resource.version
     notifies :run, 'execute[apt-get-update]', :immediately
-  end
-
-  event = new_resource.datadog_event
-  ruby_block 'datadog' do
-    block do
-      push_to_datadog(event)
-    end
-    only_if { event && event[:name] && event[:text] }
+    notifies :run, 'ruby_block[datadog]', :immediately
   end
 end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -43,8 +43,24 @@ describe 'shopify_apt_get_on_change_test::datadog' do
                         .converge(described_recipe)
   end
 
-  it 'should run the ruby block to send a datadog event' do
-    expect(chef_run).to run_ruby_block('datadog')
+  it 'should create version file with right content' do
+    expect(chef_run).to\
+      create_file('/etc/example.app/version').with_content('1.2')
+  end
+
+  it 'should do nothing if not notified' do
+    block = chef_run.ruby_block('datadog')
+    expect(block).to do_nothing
+  end
+
+  it 'should notify datadog ruby block that an update has occured' do
+    file = chef_run.file('/etc/example.app/version')
+    expect(file).to notify('ruby_block[datadog]').to(:run).immediately
+  end
+
+  it 'should send the event if notified' do
+    datadog_block = chef_run.ruby_block('datadog')
+    expect(datadog_block.only_if.first.evaluate).to be_truthy
   end
 end
 
@@ -54,8 +70,19 @@ describe 'shopify_apt_get_on_change_test::datadog_noname' do
                         .converge(described_recipe)
   end
 
-  it 'should not send an event without an event name to datadog' do
-    expect(chef_run).to_not run_ruby_block('datadog')
+  it 'should create version file with right content' do
+    expect(chef_run).to\
+      create_file('/etc/example.app/version').with_content('1.2')
+  end
+
+  it 'should notify datadog ruby block that an update has occured' do
+    file = chef_run.file('/etc/example.app/version')
+    expect(file).to notify('ruby_block[datadog]').to(:run).immediately
+  end
+
+  it 'should not send the event when notified if the name field is missing' do
+    datadog_block = chef_run.ruby_block('datadog')
+    expect(datadog_block.only_if.first.evaluate).to be_falsey
   end
 end
 
@@ -65,8 +92,19 @@ describe 'shopify_apt_get_on_change_test::datadog_notext' do
                         .converge(described_recipe)
   end
 
-  it 'should not send an event without event text to datadog' do
-    expect(chef_run).to_not run_ruby_block('datadog')
+  it 'should create version file with right content' do
+    expect(chef_run).to\
+      create_file('/etc/example.app/version').with_content('1.2')
+  end
+
+  it 'should notify datadog ruby block that an update has occured' do
+    file = chef_run.file('/etc/example.app/version')
+    expect(file).to notify('ruby_block[datadog]').to(:run).immediately
+  end
+
+  it 'should not send the event when notified if the text field is missing' do
+    datadog_block = chef_run.ruby_block('datadog')
+    expect(datadog_block.only_if.first.evaluate).to be_falsey
   end
 end
 

--- a/test/fixtures/cookbooks/shopify_apt_get_on_change_test/recipes/datadog.rb
+++ b/test/fixtures/cookbooks/shopify_apt_get_on_change_test/recipes/datadog.rb
@@ -1,10 +1,4 @@
 shopify_apt_get_on_change '/etc/example.app/version' do
-  event = {
-    name: 'name',
-    text: 'text',
-    key:  'key'
-  }
-
   version '1.2'
-  datadog_event event
+  datadog_event name: 'name', text: 'text', key: 'key'
 end

--- a/test/fixtures/cookbooks/shopify_apt_get_on_change_test/recipes/datadog_noname.rb
+++ b/test/fixtures/cookbooks/shopify_apt_get_on_change_test/recipes/datadog_noname.rb
@@ -1,9 +1,4 @@
 shopify_apt_get_on_change '/etc/example.app/version' do
-  event = {
-    text: 'text',
-    key:  'key'
-  }
-
   version '1.2'
-  datadog_event event
+  datadog_event text: 'text', key:  'key'
 end

--- a/test/fixtures/cookbooks/shopify_apt_get_on_change_test/recipes/datadog_notext.rb
+++ b/test/fixtures/cookbooks/shopify_apt_get_on_change_test/recipes/datadog_notext.rb
@@ -1,9 +1,4 @@
 shopify_apt_get_on_change '/etc/example.app/version' do
-  event = {
-    name: 'name',
-    key:  'key'
-  }
-
   version '1.2'
-  datadog_event event
+  datadog_event name: 'name', key:  'key'
 end


### PR DESCRIPTION
We only want to send the datadog event if an update the version has actually changed, not every time a chef run happens.

Change the action of the `ruby_block` to be `:nothing` so that it only runs when we notify it with `:run`.

@Shopify/traffic 