### PR TITLE
Generalize the sending of events to an on_update method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ gem 'chefspec', '~> 4.0'
 gem 'berkshelf', '4.3.2'
 gem 'foodcritic', '~> 6.2.0'
 gem 'rubocop', '~> 0.40.0'
-gem 'dogstatsd-ruby', '2.0.0'
 
 group :development do
   gem 'test-kitchen'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,6 @@ GEM
     cucumber-core (1.4.0)
       gherkin (~> 3.2.0)
     diff-lcs (1.2.5)
-    dogstatsd-ruby (2.0.0)
     erubis (2.7.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
@@ -262,7 +261,6 @@ PLATFORMS
 DEPENDENCIES
   berkshelf (= 4.3.2)
   chefspec (~> 4.0)
-  dogstatsd-ruby (= 2.0.0)
   foodcritic (~> 6.2.0)
   kitchen-vagrant
   rubocop (~> 0.40.0)

--- a/libraries/datadog_push.rb
+++ b/libraries/datadog_push.rb
@@ -1,6 +1,0 @@
-require 'datadog/statsd'
-
-def push_to_datadog(event)
-  statsd = Datadog::Statsd.new('localhost', 8125)
-  statsd.event(event[:name], event[:text], aggregation_key: event[:key])
-end

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -6,10 +6,10 @@ action :update do
     action :nothing
   end
 
-  event = new_resource.datadog_event
-  ruby_block 'datadog' do
-    block   { push_to_datadog(event) }
-    only_if { event && event[:name] && event[:text] }
+  ruby_block 'on-update' do
+    # rubocop:disable AmbiguousOperator
+    block &new_resource.on_update
+    only_if { new_resource.on_update }
     action :nothing
   end
 
@@ -19,6 +19,6 @@ action :update do
   file new_resource.base_name do
     content new_resource.version
     notifies :run, 'execute[apt-get-update]', :immediately
-    notifies :run, 'ruby_block[datadog]', :immediately
+    notifies :run, 'ruby_block[on-update]', :immediately
   end
 end

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -4,4 +4,4 @@ default_action :update if defined?(default_action)
 
 attribute :base_name, name_attribute: true, kind_of: String, required: true
 attribute :version, kind_of: String, required: true
-attribute :datadog_event, kind_of: Hash, required: false, default: nil
+attribute :on_update, kind_of: Proc, required: false, default: nil

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -22,9 +22,17 @@ describe 'shopify_apt_get_on_change_test::default' do
     expect(file).to notify('execute[apt-get-update]').to(:run).immediately
   end
 
+  it 'should create file resource that notifies the on_update ruby block' do
+    file = chef_run.file('/etc/example.app/version')
+    expect(file).to notify('ruby_block[on-update]').to(:run).immediately
+  end
+
   it 'should execute nothing' do
-    execute = chef_run.execute('apt-get-update')
-    expect(execute).to do_nothing
+    expect(chef_run.execute('apt-get-update')).to do_nothing
+  end
+
+  it 'should not run the ruby block' do
+    expect(chef_run.ruby_block('on-update')).to do_nothing
   end
 
   it 'should have the right command for execute resource' do
@@ -32,12 +40,13 @@ describe 'shopify_apt_get_on_change_test::default' do
     expect(execute.command).to eq 'apt-get -q update'
   end
 
-  it 'should not send a nil event to datadog' do
-    expect(chef_run).to_not run_ruby_block('datadog')
+  it 'should not run the ruby block without a handler given' do
+    block = chef_run.ruby_block('on-update')
+    expect(block.only_if.first.evaluate).to be_falsey
   end
 end
 
-describe 'shopify_apt_get_on_change_test::datadog' do
+describe 'shopify_apt_get_on_change_test::on_update' do
   let(:chef_run) do
     ChefSpec::SoloRunner.new(step_into: ['shopify_apt_get_on_change'])
                         .converge(described_recipe)
@@ -49,77 +58,17 @@ describe 'shopify_apt_get_on_change_test::datadog' do
   end
 
   it 'should do nothing if not notified' do
-    block = chef_run.ruby_block('datadog')
+    block = chef_run.ruby_block('on-update')
     expect(block).to do_nothing
   end
 
   it 'should notify datadog ruby block that an update has occured' do
     file = chef_run.file('/etc/example.app/version')
-    expect(file).to notify('ruby_block[datadog]').to(:run).immediately
+    expect(file).to notify('ruby_block[on-update]').to(:run).immediately
   end
 
   it 'should send the event if notified' do
-    datadog_block = chef_run.ruby_block('datadog')
-    expect(datadog_block.only_if.first.evaluate).to be_truthy
-  end
-end
-
-describe 'shopify_apt_get_on_change_test::datadog_noname' do
-  let(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['shopify_apt_get_on_change'])
-                        .converge(described_recipe)
-  end
-
-  it 'should create version file with right content' do
-    expect(chef_run).to\
-      create_file('/etc/example.app/version').with_content('1.2')
-  end
-
-  it 'should notify datadog ruby block that an update has occured' do
-    file = chef_run.file('/etc/example.app/version')
-    expect(file).to notify('ruby_block[datadog]').to(:run).immediately
-  end
-
-  it 'should not send the event when notified if the name field is missing' do
-    datadog_block = chef_run.ruby_block('datadog')
-    expect(datadog_block.only_if.first.evaluate).to be_falsey
-  end
-end
-
-describe 'shopify_apt_get_on_change_test::datadog_notext' do
-  let(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['shopify_apt_get_on_change'])
-                        .converge(described_recipe)
-  end
-
-  it 'should create version file with right content' do
-    expect(chef_run).to\
-      create_file('/etc/example.app/version').with_content('1.2')
-  end
-
-  it 'should notify datadog ruby block that an update has occured' do
-    file = chef_run.file('/etc/example.app/version')
-    expect(file).to notify('ruby_block[datadog]').to(:run).immediately
-  end
-
-  it 'should not send the event when notified if the text field is missing' do
-    datadog_block = chef_run.ruby_block('datadog')
-    expect(datadog_block.only_if.first.evaluate).to be_falsey
-  end
-end
-
-describe 'push_to_datadog' do
-  # mock out the datadog statsd
-  let(:statsd) { double('statsd') }
-  before do
-    allow(statsd).to receive(:event)
-    allow(Datadog::Statsd).to receive(:new).and_return(statsd)
-  end
-
-  it 'should send the event to datadog' do
-    expect(statsd).to\
-      receive(:event).with('name', 'text', aggregation_key: 'key')
-
-    push_to_datadog(name: 'name', text: 'text', key: 'key')
+    block = chef_run.ruby_block('on-update')
+    expect(block.only_if.first.evaluate).to be_truthy
   end
 end

--- a/test/fixtures/cookbooks/shopify_apt_get_on_change_test/recipes/datadog.rb
+++ b/test/fixtures/cookbooks/shopify_apt_get_on_change_test/recipes/datadog.rb
@@ -1,4 +1,0 @@
-shopify_apt_get_on_change '/etc/example.app/version' do
-  version '1.2'
-  datadog_event name: 'name', text: 'text', key: 'key'
-end

--- a/test/fixtures/cookbooks/shopify_apt_get_on_change_test/recipes/datadog_notext.rb
+++ b/test/fixtures/cookbooks/shopify_apt_get_on_change_test/recipes/datadog_notext.rb
@@ -1,4 +1,0 @@
-shopify_apt_get_on_change '/etc/example.app/version' do
-  version '1.2'
-  datadog_event name: 'name', key:  'key'
-end

--- a/test/fixtures/cookbooks/shopify_apt_get_on_change_test/recipes/on_update.rb
+++ b/test/fixtures/cookbooks/shopify_apt_get_on_change_test/recipes/on_update.rb
@@ -1,4 +1,4 @@
 shopify_apt_get_on_change '/etc/example.app/version' do
   version '1.2'
-  datadog_event text: 'text', key:  'key'
+  on_update -> { puts 'Hello world!' }
 end


### PR DESCRIPTION
I wanted to decouple the datadog library from this cookbook and also open up a more generalized API for having some action performed when a version change occurs.

Usage in the datadog case would be

```
chef_gem 'dogstatsd-ruby' do
  version '2.0.0'
  action :install
end

shopify_apt_get_on_change '/etc/example.app/version' do
  version '1.2'
  on_update -> do
    require 'datadog/statsd'
    statsd = Datadog::Statsd.new('localhost', 8125)
    statsd.event(event[:name], event[:text])
  end
end
```

@Shopify/traffic 

